### PR TITLE
assign _treblleResponsebody to express res object BEFORE firing the originalSend.call() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ function treblle({
     // Intercept response body
     const originalSend = res.send
     res.send = function sendOverWrite(body) {
-      originalSend.call(this, body)
       this._treblleResponsebody = body
+      originalSend.call(this, body)
     }
 
     res.on('finish', function onceFinish() {


### PR DESCRIPTION
+ calling originalSend.call(this, body) before this._treblleResponsebody = body, creates a condition where the  _treblleResponsebody assignment is never resolved, resulting in always empty responses (AWS Lambda + API , Express, NodeJS)